### PR TITLE
 Remove the `ws` dependency in favor of using the built-in `WebSocket` for React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ```bash
-npm install @trpc/client ws zod dotenv
+npm install @trpc/client zod dotenv
 npm i --save-dev @types/ws
 ```
 
+Remove ws and use the builtin WebSocket for react native. This will break the integration test for node, but make our event subscription work on react native.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessengerclient",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A React Native library to stub tRPC client for @innobridge/trpcmessenger",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/trpc/client/api.ts
+++ b/src/trpc/client/api.ts
@@ -6,7 +6,7 @@ import {
   wsLink,
   splitLink
 } from '@trpc/client';
-import WebSocket from 'ws';
+// import WebSocket from 'ws';
 import { BaseEvent } from '@/models/events';
 
 let client: TRPCClient<any> | null = null;


### PR DESCRIPTION
This pull request includes updates to remove the `ws` dependency in favor of using the built-in `WebSocket` for React Native, along with a version bump for the package. Below are the most important changes:

### Dependency and Code Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R6): Updated installation instructions to remove the `ws` package and added a note explaining the switch to the built-in `WebSocket` for React Native. This change improves compatibility with React Native but breaks the integration test for Node.js.
* [`src/trpc/client/api.ts`](diffhunk://#diff-6d205f7794a41959ae09c4797d2b9832eb8396c4f1b6efe7098219604ccf645bL9-R9): Commented out the import of the `ws` package, reflecting its removal from the project dependencies.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented the package version from `0.1.4` to `0.1.5` to reflect the changes in functionality.