### PR TITLE
fix: proper URL handling of HTTPS protocol in tRPC HTTP client initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessengerclient",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A React Native library to stub tRPC client for @innobridge/trpcmessenger",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/trpc/client/api.ts
+++ b/src/trpc/client/api.ts
@@ -15,14 +15,15 @@ let httpLink: ReturnType<typeof httpBatchLink> | null = null;
 
 const initializeTRPCClient = (url: string): void => {
   const host = url.replace(/^https?:\/\//, '');
-
+  console.log("host", host);
+  console.log("url", url);
   wsClient = createWSClient({
     url: `ws://${host}/trpc`,
     WebSocket: WebSocket as any,
   });
   
   httpLink = httpBatchLink({
-    url: `http://${host}/trpc`,
+    url: `${url}/trpc`,
     headers: () => ({
       // 'Content-Type': 'application/json',
       'Accept': 'application/json',

--- a/src/trpc/client/api.ts
+++ b/src/trpc/client/api.ts
@@ -15,8 +15,6 @@ let httpLink: ReturnType<typeof httpBatchLink> | null = null;
 
 const initializeTRPCClient = (url: string): void => {
   const host = url.replace(/^https?:\/\//, '');
-  console.log("host", host);
-  console.log("url", url);
   wsClient = createWSClient({
     url: `ws://${host}/trpc`,
     WebSocket: WebSocket as any,


### PR DESCRIPTION
This pull request includes a version bump for the package and a fix to the `initializeTRPCClient` function to ensure proper URL handling. Below are the key changes:

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.1.5` to `0.1.6`.

### URL Handling Fix:
* [`src/trpc/client/api.ts`](diffhunk://#diff-6d205f7794a41959ae09c4797d2b9832eb8396c4f1b6efe7098219604ccf645bL18-R24): Modified the `httpLink` initialization in the `initializeTRPCClient` function to use the full URL (`${url}/trpc`) instead of constructing it with a hardcoded `http://` prefix. This ensures compatibility with the provided URL format.