### PR TITLE
fix connectionId in chats to number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessengerclient",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A React Native library to stub tRPC client for @innobridge/trpcmessenger",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/models/chats.ts
+++ b/src/models/chats.ts
@@ -1,6 +1,6 @@
 interface Chat {
   chatId: string;
-  connectionId: string;
+  connectionId: number;
   userId1: string;
   userId2: string;
   createdAt: number;


### PR DESCRIPTION
This pull request includes two changes: a version bump in the `package.json` file and a type update in the `Chat` interface within `src/models/chats.ts`.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.3.2` to `0.3.3`.

Type update:

* [`src/models/chats.ts`](diffhunk://#diff-7bb6f975df973a4275fce5d97904f4d3d0b89605d9ac3ff044c0f5d2b45555a0L3-R3): Changed the type of `connectionId` in the `Chat` interface from `string` to `number`.