### PR TITLE
add update status api, but color and customerid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessengerclient",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A React Native library to stub tRPC client for @innobridge/trpcmessenger",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/trpc/client/schedule.ts
+++ b/src/trpc/client/schedule.ts
@@ -1,6 +1,5 @@
 import { client } from '@/trpc/client/api';
 import { Event, EventStatus } from '@/models/scheduledEvents';
-import { custom } from 'zod';
 
 const getEventById = async (eventId: string): Promise<Event | null> => {
     return await (client as any).schedule.getEventById.query({ eventId });
@@ -22,8 +21,20 @@ const createEvent = async (event: Event): Promise<Event> => {
     return await (client as any).schedule.createEvent.mutate(event);
 };
 
-const updateEventStatus = async (eventId: string, status: EventStatus, customerId?: string, color?: string): Promise<Event> => {
-    return await (client as any).schedule.updateEventStatus.mutate({ eventId, status, customerId, color });
+const updateEventStatus = async (eventId: string, status: EventStatus): Promise<Event> => {
+    return await (client as any).schedule.updateEventStatus.mutate({ eventId, status });
+};
+
+const updateEventStatusAndColor = async (eventId: string, status: EventStatus, color: string): Promise<Event> => {
+    return await (client as any).schedule.updateEventStatusAndColor.mutate({ eventId, status, color });
+};
+
+const updateEventStatusAndCustomerId = async (eventId: string, status: EventStatus, customerId: string): Promise<Event> => {
+    return await (client as any).schedule.updateEventStatusAndCustomerId.mutate({ eventId, status, customerId });
+};
+
+const updateEventStatusWithColorAndCustomerId = async (eventId: string, status: EventStatus, color: string, customerId: string): Promise<Event> => {
+    return await (client as any).schedule.updateEventStatusWithColorAndCustomerId.mutate({ eventId, status, color, customerId });
 };
 
 const deleteEvent = async (eventId: string): Promise<void> => {
@@ -51,6 +62,9 @@ export {
     getEventsByProviderOrCustomerId,
     createEvent,
     updateEventStatus,
+    updateEventStatusAndColor,
+    updateEventStatusAndCustomerId,
+    updateEventStatusWithColorAndCustomerId,
     deleteEvent,
     bindSubscriberToSchedule,
     unbindSubscriberToSchedule


### PR DESCRIPTION
This pull request introduces a version bump for the package and extends the functionality of the `schedule` client by adding new specialized methods for updating event statuses with additional parameters. Below is a summary of the key changes:

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.5.1` to `0.5.2`.

### Enhancements to `schedule` Client:
* [`src/trpc/client/schedule.ts`](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5L3): Removed an unused import for `custom` from `zod`, simplifying the file.
* `src/trpc/client/schedule.ts`: Refactored the `updateEventStatus` method to handle only `eventId` and `status` parameters. Introduced three new methods:
  - [`updateEventStatusAndColor`](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5L25-R37): Updates an event's status and color.
  - [`updateEventStatusAndCustomerId`](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5L25-R37): Updates an event's status and customer ID.
  - [`updateEventStatusWithColorAndCustomerId`](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5L25-R37): Updates an event's status, color, and customer ID.
* [`src/trpc/client/schedule.ts`](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5R65-R67): Exported the new methods to make them available for use.